### PR TITLE
protoc-gen-swagger: Query Parameters inherit `required` status from parent message

### DIFF
--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -109,6 +109,12 @@ func queryParams(message *descriptor.Message, field *descriptor.Field, prefix st
 		}
 	}
 
+	msgRequired := make([]string, 0)
+	msgSchema, err := extractSchemaOptionFromMessageDescriptor(message.DescriptorProto)
+	if err == nil && msgSchema != nil {
+		msgRequired = msgSchema.JsonSchema.Required
+	}
+
 	isEnum := field.GetType() == pbdescriptor.FieldDescriptorProto_TYPE_ENUM
 	items := schema.Items
 	if schema.Type != "" || isEnum {
@@ -125,7 +131,13 @@ func queryParams(message *descriptor.Message, field *descriptor.Field, prefix st
 
 		// verify if the field is required
 		required := false
-		for _, fieldName := range schema.Required {
+		for _, fieldName := range schema.Required { // check against field schema
+			if fieldName == field.GetName() {
+				required = true
+				break
+			}
+		}
+		for _, fieldName := range msgRequired { // check against containg message's schema
 			if fieldName == field.GetName() {
 				required = true
 				break


### PR DESCRIPTION
Short on time, so here is jist:

Marking required fields at a `message` level does not mark query parameters as `required`.

```protobuf
message EchoRequest {
    option (grpc.gateway.protoc_gen_swagger.options.openapiv2_schema) = {
		json_schema: {
			required: ["id"]
		}
	};
	// Id represents the message identifier.
	string id = 1;
	int64 num = 2;
}
```

results in 

```json
        "parameters": [
          {
            "name": "id",
            "description": "Id represents the message identifier.",
            "in": "query",
            "required": false,
            "type": "string"
          },
          {
            "name": "num",
            "in": "query",
            "required": false,
            "type": "string",
            "format": "int64"
          }
        ],
```

With this change `id` would be marked as required.